### PR TITLE
Enable periodic rerun when conversation pauses

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -494,6 +494,8 @@ def main():
             else:
                 remaining = 2 - (current_time - st.session_state.last_message_time)
                 st.write(f"🔍 デバッグ: 待機中...あと{remaining:.1f}秒で次のメッセージ")
+                time.sleep(remaining)
+                st.rerun()
             
             if should_step:
                 st.write("🔍 デバッグ: conversation_step()を実行します")


### PR DESCRIPTION
## Summary
- rerun Streamlit app after a short delay even when no new message is produced

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68430796c5c883239cc7b1d2e0bdab42